### PR TITLE
Downgrade Go version from 1.22 to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Autodoc-Technology/redis-nats-proxy
 
-go 1.22.0
+go 1.21
 
 require (
 	github.com/nats-io/nats.go v1.34.0


### PR DESCRIPTION
The Go version in the module definition was changed from 1.22.0 to 1.21. This is to ensure compatibility across different environments that may not yet support the latest version.